### PR TITLE
Apply crack weighting in strain energy computation

### DIFF
--- a/src/crack_geometry.py
+++ b/src/crack_geometry.py
@@ -1,22 +1,25 @@
 import torch
-from src.utils import bmv, bdot
 
 class CrackGeometry:
-    """
-    Defines the geometry of a crack in a 2D plane.
-    """
-    def __init__(self, crack_type='center', crack_param=None):
-        """
-        Initializes the crack geometry.
+    """Geometry representation of planar cracks."""
 
-        Args:
-            crack_type (str): The type of crack ('center', 'edge', 'inclined').
-            crack_param (dict): A dictionary of parameters defining the crack.
-                                For 'center' and 'edge': {'length': float}
-                                For 'inclined': {'length': float, 'angle': float}
+    def __init__(self, crack_type: str = 'center', crack_param=None, smoothing: float = 0.0):
+        """Initialize the crack geometry.
+
+        Parameters
+        ----------
+        crack_type: str
+            Type of crack ('center', 'edge', 'inclined').
+        crack_param: dict
+            Parameters describing the crack. For 'center' and 'edge':
+            ``{'length': float}``; for 'inclined': ``{'length': float, 'angle': float}``.
+        smoothing: float, optional
+            Width of the smoothing region for the crack embedding. A value of
+            ``0`` yields a sharp sign function.
         """
         self.crack_type = crack_type
         self.crack_param = crack_param
+        self.smoothing = smoothing
 
     def sdf(self, points):
         """
@@ -98,4 +101,6 @@ class CrackGeometry:
             torch.Tensor: The crack embedding values.
         """
         sdf_values = self.sdf(points)
+        if self.smoothing and self.smoothing > 0.0:
+            return torch.tanh(sdf_values / self.smoothing)
         return torch.sign(sdf_values)


### PR DESCRIPTION
## Summary
- instantiate a `CrackGeometry` with smoothing and add penalty coefficient
- weight membrane, bending, and shear energies by crack embedding
- include optional crack continuity penalty and smoothing support in `CrackGeometry`

## Testing
- `python -m py_compile main.py src/crack_geometry.py`
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6895be1f6288832389b50ff837dd2a95